### PR TITLE
Enable twincat router support in cmake + upstream updates 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ build-win10:
 
 .test-linux:
   stage: test
-  image: ${REGISTRY_HOST}/beckhoff/test_stage/test_runner:4.3
+  image: ${REGISTRY_HOST}/beckhoff/test_stage/test_runner:4.5
   tags:
     - docker_vm_runner
     - few_vcpus

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ build-win10:
     EXPECTED_PLATFORMID: 92
     EXPECTED_SYSTEMID: '95EEFDE0-0392-1452-275F-1BF9ACCB924E'
   script:
-    - apt update -y && apt install -y xxd
+    - apt update -y && apt install -y socat xxd
     - ./tools/90_run_tests.sh
 
 test-linux-clang:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ build-linux-gcc-mips:
 build-mxe:
   extends: .build-meson-docker
   variables:
-    BHF_CI_MESON_OPTIONS: '--cross-file meson.cross.amd64-linux.win32 -Dcpp_std=c++11 -Db_pie=false'
+    BHF_CI_MESON_OPTIONS: '--cross-file meson.cross.amd64-linux.win32 -Dcpp_std=c++14 -Db_pie=false'
 
 build-win10:
   extends: .build-meson

--- a/AdsLib/AdsDef.cpp
+++ b/AdsLib/AdsDef.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2016 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AdsDef.h"

--- a/AdsLib/AdsDef.h
+++ b/AdsLib/AdsDef.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2020 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
+
 #pragma once
 
 #if defined(USE_TWINCAT_ROUTER)

--- a/AdsLib/AdsDevice.cpp
+++ b/AdsLib/AdsDevice.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2016 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2016 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AdsDevice.h"

--- a/AdsLib/AdsDevice.h
+++ b/AdsLib/AdsDevice.h
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2016 - 2020 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2016 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once
+
 #include "AdsException.h"
 #include "AdsDef.h"
 #include "wrap_endian.h"

--- a/AdsLib/AdsException.h
+++ b/AdsLib/AdsException.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+/**
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
+ */
+
 #pragma once
 
 #include <stdexcept>

--- a/AdsLib/AdsFile.cpp
+++ b/AdsLib/AdsFile.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2020 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AdsFile.h"

--- a/AdsLib/AdsFile.h
+++ b/AdsLib/AdsFile.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2020 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/AdsLib.cpp
+++ b/AdsLib/AdsLib.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AdsLib.h"

--- a/AdsLib/AdsLib.cpp
+++ b/AdsLib/AdsLib.cpp
@@ -47,7 +47,7 @@ enum UdpServiceId : uint32_t {
     RESPONSE = 0x80000000,
 };
 
-static long SendRecv(const IpV4 remote, Frame& f, const uint32_t serviceId)
+static long SendRecv(const std::string& remote, Frame& f, const uint32_t serviceId)
 {
     f.prepend(htole(serviceId));
 
@@ -57,7 +57,8 @@ static long SendRecv(const IpV4 remote, Frame& f, const uint32_t serviceId)
     static const uint32_t UDP_COOKIE = 0x71146603;
     f.prepend(htole(UDP_COOKIE));
 
-    UdpSocket s{remote, 48899};
+    const auto addresses = GetListOfAddresses(remote, "48899");
+    UdpSocket s{addresses.get()};
     s.write(f);
     f.reset();
 
@@ -87,7 +88,7 @@ static long SendRecv(const IpV4 remote, Frame& f, const uint32_t serviceId)
     return 0;
 }
 
-long AddRemoteRoute(const IpV4         remote,
+long AddRemoteRoute(const std::string& remote,
                     AmsNetId           destNetId,
                     const std::string& destAddr,
                     const std::string& routeName,
@@ -147,7 +148,7 @@ long AddRemoteRoute(const IpV4         remote,
     return ADSERR_DEVICE_INVALIDDATA;
 }
 
-long GetRemoteAddress(const IpV4 remote, AmsNetId& netId)
+long GetRemoteAddress(const std::string& remote, AmsNetId& netId)
 {
     Frame f { 128 };
 

--- a/AdsLib/AdsLib.h
+++ b/AdsLib/AdsLib.h
@@ -183,7 +183,7 @@ void SetLocalAddress(AmsNetId ams);
  * @param[in] remotePassword password for the user on the remote TwinCAT system
  * @return [ADS Return Code](https://infosys.beckhoff.com/content/1031/tcadscommon/html/ads_returncodes.htm?id=1666172286265530469)
  */
-long AddRemoteRoute(const IpV4         remote,
+long AddRemoteRoute(const std::string& remote,
                     AmsNetId           destNetId,
                     const std::string& destAddr,
                     const std::string& routeName,
@@ -196,8 +196,8 @@ long AddRemoteRoute(const IpV4         remote,
  * @param[out] netId on success the AmsNetId of the remote TwinCAT system is written here
  * @return [ADS Return Code](https://infosys.beckhoff.com/content/1031/tcadscommon/html/ads_returncodes.htm?id=1666172286265530469)
  */
-long GetRemoteAddress(const IpV4 remote,
-                      AmsNetId&  netId);
+long GetRemoteAddress(const std::string& remote,
+                      AmsNetId&          netId);
 }
 }
 

--- a/AdsLib/AdsLib.h
+++ b/AdsLib/AdsLib.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2020 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
  */
+
 #pragma once
 
 #if defined(USE_TWINCAT_ROUTER)

--- a/AdsLib/AdsNotification.h
+++ b/AdsLib/AdsNotification.h
@@ -1,27 +1,9 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
-#ifndef _ADS_NOTIFICATION_H_
-#define _ADS_NOTIFICATION_H_
+#pragma once
 
 #include "AdsDef.h"
 #include "RingBuffer.h"
@@ -76,5 +58,3 @@ private:
     const std::shared_ptr<uint8_t> buffer;
     const uint32_t hUser;
 };
-
-#endif /* #ifndef _ADS_NOTIFICATION_H_ */

--- a/AdsLib/AdsNotification.h
+++ b/AdsLib/AdsNotification.h
@@ -38,7 +38,7 @@ struct Notification {
             data[i] = ring.ReadFromLittleEndian<uint8_t>();
         }
         header->nTimeStamp = timestamp;
-        callback(&connection.second, header, hUser);
+        callback(const_cast<AmsAddr*>(&connection.second), header, hUser);
     }
 
     uint32_t Size() const

--- a/AdsLib/AdsNotificationOOI.h
+++ b/AdsLib/AdsNotificationOOI.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+/**
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
+ */
+
 #pragma once
 
 #include "AdsDevice.h"

--- a/AdsLib/AdsVariable.h
+++ b/AdsLib/AdsVariable.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+/**
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
+ */
+
 #pragma once
 
 #include "AdsDevice.h"

--- a/AdsLib/AmsConnection.h
+++ b/AdsLib/AmsConnection.h
@@ -75,6 +75,14 @@ struct AmsConnection {
     long DeleteNotification(const AmsAddr& amsAddr, uint32_t hNotify, uint32_t tmms, uint16_t port);
     long AdsRequest(AmsRequest& request, uint32_t timeout);
 
+    /**
+     * Confirm if this AmsConnection is connected to one of the target addresses.
+     * @param[in] targetAddresses pointer to a previously allocated list of
+     *           "struct addrinfo" returned by getaddrinfo(3).
+     * @return true, this connection can be used to reach one of the targetAddresses.
+     */
+    bool IsConnectedTo(const struct addrinfo* targetAddresses) const;
+
 private:
     friend struct AmsRouter;
     Router& router;

--- a/AdsLib/AmsConnection.h
+++ b/AdsLib/AmsConnection.h
@@ -68,7 +68,7 @@ private:
 };
 
 struct AmsConnection {
-    AmsConnection(Router& __router, IpV4 destIp = IpV4 { "" });
+    AmsConnection(Router& __router, const struct addrinfo* destination = nullptr);
     ~AmsConnection();
 
     SharedDispatcher CreateNotifyMapping(uint32_t hNotify, std::shared_ptr<Notification> notification);
@@ -111,6 +111,5 @@ private:
     SharedDispatcher DispatcherListGet(const VirtualConnection& connection);
 
 public:
-    const IpV4 destIp;
     const uint32_t ownIp;
 };

--- a/AdsLib/AmsConnection.h
+++ b/AdsLib/AmsConnection.h
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/AmsHeader.h
+++ b/AdsLib/AmsHeader.h
@@ -1,27 +1,9 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
-#ifndef AMSHEADER_H
-#define AMSHEADER_H
+#pragma once
 
 #define UNUSED(x) (void)(x)
 
@@ -270,4 +252,3 @@ private:
     uint32_t leReadLength;
 };
 #pragma pack (pop)
-#endif // AMSHEADER_H

--- a/AdsLib/AmsPort.h
+++ b/AdsLib/AmsPort.h
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/AmsRouter.h
+++ b/AdsLib/AmsRouter.h
@@ -1,27 +1,9 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
-#ifndef _AMS_ROUTER_H_
-#define _AMS_ROUTER_H_
+#pragma once
 
 #include "AmsConnection.h"
 
@@ -53,4 +35,3 @@ private:
 
     std::array<AmsPort, NUM_PORTS_MAX> ports;
 };
-#endif /* #ifndef _AMS_ROUTER_H_ */

--- a/AdsLib/AmsRouter.h
+++ b/AdsLib/AmsRouter.h
@@ -20,6 +20,7 @@ struct AmsRouter : Router {
     long AddNotification(AmsRequest& request, uint32_t* pNotification, std::shared_ptr<Notification> notify);
     long DelNotification(uint16_t port, const AmsAddr* pAddr, uint32_t hNotification);
 
+    [[deprecated]]
     long AddRoute(AmsNetId ams, const IpV4& ip);
     long AddRoute(AmsNetId ams, const std::string& host);
     void DelRoute(const AmsNetId& ams);

--- a/AdsLib/AmsRouter.h
+++ b/AdsLib/AmsRouter.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "AmsConnection.h"
+#include <unordered_set>
 
 struct AmsRouter : Router {
     AmsRouter(AmsNetId netId = AmsNetId {});
@@ -20,6 +21,7 @@ struct AmsRouter : Router {
     long DelNotification(uint16_t port, const AmsAddr* pAddr, uint32_t hNotification);
 
     long AddRoute(AmsNetId ams, const IpV4& ip);
+    long AddRoute(AmsNetId ams, const std::string& host);
     void DelRoute(const AmsNetId& ams);
     AmsConnection* GetConnection(const AmsNetId& pAddr);
     long AdsRequest(AmsRequest& request);
@@ -27,10 +29,9 @@ struct AmsRouter : Router {
 private:
     AmsNetId localAddr;
     std::recursive_mutex mutex;
-    std::map<IpV4, std::unique_ptr<AmsConnection> > connections;
+    std::unordered_set<std::unique_ptr<AmsConnection> > connections;
     std::map<AmsNetId, AmsConnection*> mapping;
 
-    std::map<IpV4, std::unique_ptr<AmsConnection> >::iterator __GetConnection(const AmsNetId& pAddr);
     void DeleteIfLastConnection(const AmsConnection* conn);
 
     std::array<AmsPort, NUM_PORTS_MAX> ports;

--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -26,7 +26,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   target_link_libraries(ads PUBLIC wsock32)
 endif()
 
-if(${WIN32} EQUAL 1)
+
+if(WIN32 EQUAL 1)
     target_link_libraries(ads PUBLIC ws2_32)
 endif()
 

--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -1,9 +1,15 @@
 set(SOURCES
-  AdsDevice.cpp
   AdsDef.cpp
-  Log.cpp
-  Sockets.cpp
+  AdsDevice.cpp
+  AdsFile.cpp
+  AdsLib.cpp
   Frame.cpp
+  LicenseAccess.cpp
+  Log.cpp
+  RouterAccess.cpp
+  RTimeAccess.cpp
+  Sockets.cpp
+
   standalone/AdsLib.cpp
   standalone/AmsConnection.cpp
   standalone/AmsNetId.cpp
@@ -17,8 +23,11 @@ add_library(ads ${SOURCES})
 target_include_directories(ads PUBLIC .)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_link_libraries(ads PUBLIC wsock32 ws2_32)
+  target_link_libraries(ads PUBLIC wsock32)
 endif()
 
+if(${WIN32} EQUAL 1)
+    target_link_libraries(ads PUBLIC ws2_32)
+endif()
 
 target_link_libraries(ads PUBLIC Threads::Threads)

--- a/AdsLib/CMakeLists.txt
+++ b/AdsLib/CMakeLists.txt
@@ -1,31 +1,34 @@
-set(SOURCES
-  AdsDef.cpp
-  AdsDevice.cpp
-  AdsFile.cpp
-  AdsLib.cpp
-  Frame.cpp
-  LicenseAccess.cpp
-  Log.cpp
-  RouterAccess.cpp
-  RTimeAccess.cpp
-  Sockets.cpp
+file(GLOB BASE_SOURCES LIST_DIRECTORIES false CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/*.cpp")
+file(GLOB_RECURSE MY_HEADERS "${CMAKE_CURRENT_LIST_DIR}/*.h")
 
-  standalone/AdsLib.cpp
-  standalone/AmsConnection.cpp
-  standalone/AmsNetId.cpp
-  standalone/AmsPort.cpp
-  standalone/AmsRouter.cpp
-  standalone/NotificationDispatcher.cpp
+if (ADS_USE_TWINCAT_ROUTER STREQUAL "ON")
+    if (NOT DEFINED ENV{TWINCAT3DIR}) 
+        message(FATAL_ERROR "Expected TWINCAT3DIR env-var to be set. Please install TwinCAT/XAE!")
+    endif()
+    file(GLOB ROUTER_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/TwinCAT/*.cpp")
+else ()
+    file(GLOB ROUTER_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_LIST_DIR}/standalone/*.cpp")
+endif()
+
+add_library(ads
+    ${BASE_SOURCES}
+    ${ROUTER_SOURCES}
+    ${MY_HEADERS}
 )
-
-add_library(ads ${SOURCES})
 
 target_include_directories(ads PUBLIC .)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  target_link_libraries(ads PUBLIC wsock32)
+if (ADS_USE_TWINCAT_ROUTER STREQUAL "ON")
+    target_compile_definitions(ads PUBLIC USE_TWINCAT_ROUTER)
+    target_include_directories(ads PUBLIC "$ENV{TWINCAT3DIR}\\..\\AdsApi\\TcAdsDll\\include")
+    target_link_libraries(ads PUBLIC "$ENV{TWINCAT3DIR}\\..\\AdsApi\\TcAdsDll\\x64\\lib\\TcAdsDll.lib")
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  target_link_libraries(ads PUBLIC wsock32)
+else()
+  target_compile_options(ads PUBLIC -fPIC)
+endif()
 
 if(WIN32 EQUAL 1)
     target_link_libraries(ads PUBLIC ws2_32)

--- a/AdsLib/Frame.cpp
+++ b/AdsLib/Frame.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "Frame.h"

--- a/AdsLib/Frame.h
+++ b/AdsLib/Frame.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/LicenseAccess.cpp
+++ b/AdsLib/LicenseAccess.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "LicenseAccess.h"

--- a/AdsLib/LicenseAccess.h
+++ b/AdsLib/LicenseAccess.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/Log.cpp
+++ b/AdsLib/Log.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-    Copyright (c) 2015 -2021 Beckhoff Automation GmbH & Co. KG
+    Copyright (c) 2015 -2022 Beckhoff Automation GmbH & Co. KG
     Author: Patrick Bruenn <p.bruenn@beckhoff.com>
  */
 

--- a/AdsLib/Log.h
+++ b/AdsLib/Log.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-    Copyright (c) 2015 -2021 Beckhoff Automation GmbH & Co. KG
+    Copyright (c) 2015 -2022 Beckhoff Automation GmbH & Co. KG
     Author: Patrick Bruenn <p.bruenn@beckhoff.com>
  */
 

--- a/AdsLib/NotificationDispatcher.h
+++ b/AdsLib/NotificationDispatcher.h
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/RTimeAccess.cpp
+++ b/AdsLib/RTimeAccess.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "RTimeAccess.h"

--- a/AdsLib/RTimeAccess.h
+++ b/AdsLib/RTimeAccess.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/RingBuffer.h
+++ b/AdsLib/RingBuffer.h
@@ -1,27 +1,9 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
-#ifndef _RING_BUFFER_H_
-#define _RING_BUFFER_H_
+#pragma once
 
 #include <cassert>
 #include <cstdint>
@@ -84,4 +66,3 @@ public:
     uint8_t* write;
     const uint8_t* read;
 };
-#endif /* #ifndef _RING_BUFFER_H_ */

--- a/AdsLib/Router.h
+++ b/AdsLib/Router.h
@@ -1,27 +1,9 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
-#ifndef _ROUTER_H_
-#define _ROUTER_H_
+#pragma once
 
 #include "AdsDef.h"
 
@@ -33,4 +15,3 @@ struct Router {
 
     virtual long GetLocalAddress(uint16_t port, AmsAddr* pAddr) = 0;
 };
-#endif /* #ifndef _ROUTER_H_ */

--- a/AdsLib/RouterAccess.cpp
+++ b/AdsLib/RouterAccess.cpp
@@ -29,18 +29,18 @@ private:
 
 struct SearchPciSlotResNew {
     static constexpr size_t MAXBASEADDRESSES = 6;
-    const std::array<uint32_t, MAXBASEADDRESSES> leBaseAddresses;
-    const uint32_t leSize[MAXBASEADDRESSES];
-    const uint32_t leBusNumber;
-    const uint32_t leSlotNumber;
-    const uint16_t leBoardIrq;
-    const uint16_t lePciRegViaPorts;
+    std::array<uint32_t, MAXBASEADDRESSES> leBaseAddresses;
+    uint32_t leSize[MAXBASEADDRESSES];
+    uint32_t leBusNumber;
+    uint32_t leSlotNumber;
+    uint16_t leBoardIrq;
+    uint16_t lePciRegViaPorts;
 };
 
 struct SearchPciBusResNew {
     static constexpr size_t MAXSLOTRESPONSE = 64;
-    uint32_t leFound;
-    std::array<SearchPciSlotResNew, MAXSLOTRESPONSE> slot;
+    uint32_t leFound {};
+    std::array<SearchPciSlotResNew, MAXSLOTRESPONSE> slot {};
     uint32_t nFound() const
     {
         return bhf::ads::letoh(leFound);
@@ -63,7 +63,7 @@ bool RouterAccess::PciScan(const uint64_t pci_id, std::ostream& os) const
 #define ROUTERADSGRP_ACCESS_HARDWARE 0x00000005
 #define ROUTERADSOFFS_A_HW_SEARCHPCIBUS 0x00000003
 
-    SearchPciBusResNew res {};
+    SearchPciBusResNew res;
     uint32_t bytesRead;
 
     const auto req = SearchPciBusReq {pci_id};
@@ -82,7 +82,7 @@ bool RouterAccess::PciScan(const uint64_t pci_id, std::ostream& os) const
 
     if (res.slot.size() < res.nFound()) {
         LOG_WARN(__FUNCTION__
-                 << "(): data seems corrupt. Slot count 0x" << std::hex << res.nFound() << " exceedes maximum 0x" << res.slot.size() <<
+                 << "(): data seems corrupt. Slot count 0x" << std::hex << res.nFound() << " exceeds maximum 0x" << res.slot.size() <<
                  " -> truncating\n");
     }
 

--- a/AdsLib/RouterAccess.cpp
+++ b/AdsLib/RouterAccess.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "RouterAccess.h"

--- a/AdsLib/RouterAccess.h
+++ b/AdsLib/RouterAccess.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/Semaphore.h
+++ b/AdsLib/Semaphore.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 -2020 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2015 - 2020 Beckhoff Automation GmbH & Co. KG
    Author: Patrick Bruenn <p.bruenn@beckhoff.com>
  */
 

--- a/AdsLib/Sockets.cpp
+++ b/AdsLib/Sockets.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2016 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "Sockets.h"

--- a/AdsLib/Sockets.cpp
+++ b/AdsLib/Sockets.cpp
@@ -192,6 +192,20 @@ uint32_t TcpSocket::Connect() const
     return ntohl(source.sin_addr.s_addr);
 }
 
+bool TcpSocket::IsConnectedTo(const struct addrinfo* const targetAddresses) const
+{
+    for (auto rp = targetAddresses; rp; rp = rp->ai_next) {
+        if (m_SockAddress.sin_family == rp->ai_family) {
+            if (!memcmp(&m_SockAddress.sin_addr, &(((struct sockaddr_in*)(rp->ai_addr))->sin_addr),
+                        sizeof(m_SockAddress.sin_addr)))
+            {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 UdpSocket::UdpSocket(IpV4 ip, uint16_t port)
     : Socket(ip, port, SOCK_DGRAM)
 {}

--- a/AdsLib/Sockets.cpp
+++ b/AdsLib/Sockets.cpp
@@ -13,6 +13,22 @@
 #include <sstream>
 #include <system_error>
 
+namespace bhf
+{
+namespace ads
+{
+AddressList GetListOfAddresses(const std::string& host, const std::string& service)
+{
+    struct addrinfo* results;
+
+    if (getaddrinfo(host.c_str(), service.c_str(), nullptr, &results)) {
+        throw std::runtime_error("Invalid or unknown host: " + host);
+    }
+    return AddressList { results, [](struct addrinfo* p) { freeaddrinfo(p); }};
+}
+}
+}
+
 static const struct addrinfo addrinfo = []() {
                                             struct addrinfo a;
                                             memset(&a, 0, sizeof(a));

--- a/AdsLib/Sockets.h
+++ b/AdsLib/Sockets.h
@@ -15,7 +15,11 @@ namespace bhf
 namespace ads
 {
 using AddressList = std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)>;
-AddressList GetListOfAddresses(const std::string& host, const std::string& service = {});
+/**
+ * Splits the provided host string into host and port. If no port was found
+ * in the host string, the provided default port is used.
+ */
+AddressList GetListOfAddresses(const std::string& hostPort, const std::string& defaultPort = {});
 }
 }
 

--- a/AdsLib/Sockets.h
+++ b/AdsLib/Sockets.h
@@ -44,6 +44,14 @@ protected:
 struct TcpSocket : Socket {
     TcpSocket(IpV4 ip, uint16_t port);
     uint32_t Connect() const;
+
+    /**
+     * Confirm if this TcpSocket is connected to one of the target addresses.
+     * @param[in] targetAddresses pointer to a previously allocated list of
+     *           "struct addrinfo" returned by getaddrinfo(3).
+     * @return true, this connection can be used to reach one of the targetAddresses.
+     */
+    bool IsConnectedTo(const struct addrinfo* targetAddresses) const;
 };
 
 struct UdpSocket : Socket {

--- a/AdsLib/Sockets.h
+++ b/AdsLib/Sockets.h
@@ -1,27 +1,9 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
-#ifndef UDPSOCKET_H
-#define UDPSOCKET_H
+#pragma once
 
 #include "Frame.h"
 #include "wrap_socket.h"
@@ -67,5 +49,3 @@ struct TcpSocket : Socket {
 struct UdpSocket : Socket {
     UdpSocket(IpV4 ip, uint16_t port);
 };
-
-#endif // UDPSOCKET_H

--- a/AdsLib/Sockets.h
+++ b/AdsLib/Sockets.h
@@ -10,6 +10,15 @@
 #include <stdexcept>
 #include <string>
 
+namespace bhf
+{
+namespace ads
+{
+using AddressList = std::unique_ptr<struct addrinfo, void (*)(struct addrinfo*)>;
+AddressList GetListOfAddresses(const std::string& host, const std::string& service = {});
+}
+}
+
 struct IpV4 {
     const uint32_t value;
     IpV4(const std::string& addr);

--- a/AdsLib/Sockets.h
+++ b/AdsLib/Sockets.h
@@ -41,17 +41,17 @@ struct Socket {
 protected:
     int m_WSAInitialized;
     SOCKET m_Socket;
-    sockaddr_in m_SockAddress;
+    sockaddr_storage m_SockAddress;
     const sockaddr* const m_DestAddr;
-    const size_t m_DestAddrLen;
+    size_t m_DestAddrLen;
 
-    Socket(IpV4 ip, uint16_t port, int type);
+    Socket(const struct addrinfo* host, int type);
     ~Socket();
     bool Select(timeval* timeout) const;
 };
 
 struct TcpSocket : Socket {
-    TcpSocket(IpV4 ip, uint16_t port);
+    TcpSocket(const struct addrinfo* host);
     uint32_t Connect() const;
 
     /**
@@ -64,5 +64,5 @@ struct TcpSocket : Socket {
 };
 
 struct UdpSocket : Socket {
-    UdpSocket(IpV4 ip, uint16_t port);
+    UdpSocket(const struct addrinfo* host);
 };

--- a/AdsLib/TwinCAT/AdsDef.h
+++ b/AdsLib/TwinCAT/AdsDef.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2020 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 #pragma once
 #ifdef __FreeBSD__

--- a/AdsLib/TwinCAT/AdsLib.cpp
+++ b/AdsLib/TwinCAT/AdsLib.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2020 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AdsLib.h"

--- a/AdsLib/TwinCAT/AdsLib.h
+++ b/AdsLib/TwinCAT/AdsLib.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2020 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 #pragma once
 

--- a/AdsLib/standalone/AdsDef.h
+++ b/AdsLib/standalone/AdsDef.h
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /** @file
-   Copyright (c) 2015 - 2016 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/standalone/AdsLib.cpp
+++ b/AdsLib/standalone/AdsLib.cpp
@@ -32,7 +32,7 @@ namespace ads
 long AddLocalRoute(const AmsNetId ams, const char* ip)
 {
     try {
-        return GetRouter().AddRoute(ams, IpV4(ip));
+        return GetRouter().AddRoute(ams, ip);
     } catch (const std::bad_alloc&) {
         return GLOBALERR_NO_MEMORY;
     } catch (const std::runtime_error&) {

--- a/AdsLib/standalone/AdsLib.cpp
+++ b/AdsLib/standalone/AdsLib.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2021 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AdsLib.h"

--- a/AdsLib/standalone/AdsLib.h
+++ b/AdsLib/standalone/AdsLib.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /** @file
-   Copyright (c) 2015 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 #pragma once
 

--- a/AdsLib/standalone/AmsConnection.cpp
+++ b/AdsLib/standalone/AmsConnection.cpp
@@ -98,6 +98,11 @@ long AmsConnection::DeleteNotification(const AmsAddr& amsAddr, uint32_t hNotify,
     return AdsRequest(request, tmms);
 }
 
+bool AmsConnection::IsConnectedTo(const struct addrinfo* targetAddresses) const
+{
+    return socket.IsConnectedTo(targetAddresses);
+}
+
 AmsResponse* AmsConnection::Write(AmsRequest& request, const AmsAddr srcAddr)
 {
     const AoEHeader aoeHeader {

--- a/AdsLib/standalone/AmsConnection.cpp
+++ b/AdsLib/standalone/AmsConnection.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AmsConnection.h"

--- a/AdsLib/standalone/AmsConnection.cpp
+++ b/AdsLib/standalone/AmsConnection.cpp
@@ -61,12 +61,11 @@ SharedDispatcher AmsConnection::DispatcherListGet(const VirtualConnection& conne
     return {};
 }
 
-AmsConnection::AmsConnection(Router& __router, IpV4 __destIp)
+AmsConnection::AmsConnection(Router& __router, const struct addrinfo* const destination)
     : router(__router),
-    socket(__destIp, ADS_TCP_SERVER_PORT),
+    socket(destination),
     refCount(0),
     invokeId(0),
-    destIp(__destIp),
     ownIp(socket.Connect())
 {
     receiver = std::thread(&AmsConnection::TryRecv, this);

--- a/AdsLib/standalone/AmsNetId.cpp
+++ b/AdsLib/standalone/AmsNetId.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2020 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2020 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AdsDef.h"

--- a/AdsLib/standalone/AmsPort.cpp
+++ b/AdsLib/standalone/AmsPort.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AmsPort.h"

--- a/AdsLib/standalone/AmsRouter.cpp
+++ b/AdsLib/standalone/AmsRouter.cpp
@@ -51,7 +51,7 @@ long AmsRouter::AddRoute(AmsNetId ams, const std::string& host)
         }
     }
 
-    auto conn = connections.emplace(std::unique_ptr<AmsConnection>(new AmsConnection { *this, host}));
+    auto conn = connections.emplace(std::unique_ptr<AmsConnection>(new AmsConnection { *this, hostAddresses.get()}));
     if (conn.second) {
         /** in case no local AmsNetId was set previously, we derive one */
         if (!localAddr) {

--- a/AdsLib/standalone/AmsRouter.cpp
+++ b/AdsLib/standalone/AmsRouter.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "AmsRouter.h"

--- a/AdsLib/standalone/NotificationDispatcher.cpp
+++ b/AdsLib/standalone/NotificationDispatcher.cpp
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include "NotificationDispatcher.h"

--- a/AdsLib/wrap_endian.h
+++ b/AdsLib/wrap_endian.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLib/wrap_socket.h
+++ b/AdsLib/wrap_socket.h
@@ -1,23 +1,6 @@
+// SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2018 Beckhoff Automation GmbH & Co. KG
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-   SOFTWARE.
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #pragma once

--- a/AdsLibOOITest/main.cpp
+++ b/AdsLibOOITest/main.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+/**
+   Copyright (c) 2017 - 2022 Beckhoff Automation GmbH & Co. KG
+ */
 
 #include "AdsVariable.h"
 #include "AdsDevice.h"

--- a/AdsLibTest/main.cpp
+++ b/AdsLibTest/main.cpp
@@ -98,32 +98,26 @@ struct TestAmsRouter : test_base<TestAmsRouter> {
         static const AmsNetId netId_1 { 192, 168, 0, 231, 1, 1 };
         static const AmsNetId netId_2 { 127, 0, 0, 1, 2, 1 };
         static const auto local_name = "127.0.0.1";
-        static const IpV4 ip_local(local_name);
         AmsRouter testee;
 
         // test new Ams with new Ip
         fructose_assert(0 == testee.AddRoute(netId_1, local_name));
         fructose_assert(!!testee.GetConnection(netId_1));
-        fructose_assert(ip_local == testee.GetConnection(netId_1)->destIp);
 
         // existent Ams with new Ip -> close old connection manually, now
         fructose_assert(ROUTERERR_PORTALREADYINUSE == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
-        fructose_assert(ip_local == testee.GetConnection(netId_1)->destIp);
         testee.DelRoute(netId_1);
         fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
-        fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
 
         // new Ams with existent Ip
         fructose_assert(0 == testee.AddRoute(netId_2, remote_name));
         fructose_assert(!!testee.GetConnection(netId_2));
-        fructose_assert(ip_remote == testee.GetConnection(netId_2)->destIp);
 
         // already exists
         fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
-        fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
     }
 
     void testAmsRouterDelRoute(const std::string&)
@@ -131,23 +125,19 @@ struct TestAmsRouter : test_base<TestAmsRouter> {
         static const AmsNetId netId_1 { 192, 168, 0, 231, 1, 1 };
         static const AmsNetId netId_2 { 127, 0, 0, 1, 2, 1 };
         static const auto local_name = "127.0.0.1";
-        static const IpV4 ip_local(local_name);
         AmsRouter testee;
 
         // add + remove -> null
         fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
-        fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
         testee.DelRoute(netId_1);
         fructose_assert(!testee.GetConnection(netId_1));
 
         // add_1, add_2, remove_1 -> null_1 valid_2
         fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
-        fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
         fructose_assert(0 == testee.AddRoute(netId_2, local_name));
         fructose_assert(!!testee.GetConnection(netId_2));
-        fructose_assert(ip_local == testee.GetConnection(netId_2)->destIp);
         testee.DelRoute(netId_1);
         fructose_assert(!testee.GetConnection(netId_1));
         fructose_assert(!!testee.GetConnection(netId_2));
@@ -190,7 +180,6 @@ private:
             AmsNetId netId {192, 168, 0, i, 0, id};
             fructose_assert_eq(0, testee.AddRoute(netId, remote_name));
             fructose_assert(!!testee.GetConnection(netId));
-            fructose_assert(ip_remote == testee.GetConnection(netId)->destIp);
         }
 
         for (uint8_t i = 0; i < 255; ++i) {

--- a/AdsLibTest/main.cpp
+++ b/AdsLibTest/main.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-   Copyright (c) 2015 - 2021 Beckhoff Automation GmbH & Co. KG
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
  */
 
 #include <AdsLib.h>

--- a/AdsLibTest/main.cpp
+++ b/AdsLibTest/main.cpp
@@ -97,30 +97,31 @@ struct TestAmsRouter : test_base<TestAmsRouter> {
     {
         static const AmsNetId netId_1 { 192, 168, 0, 231, 1, 1 };
         static const AmsNetId netId_2 { 127, 0, 0, 1, 2, 1 };
-        static const IpV4 ip_local("127.0.0.1");
+        static const auto local_name = "127.0.0.1";
+        static const IpV4 ip_local(local_name);
         AmsRouter testee;
 
         // test new Ams with new Ip
-        fructose_assert(0 == testee.AddRoute(netId_1, ip_local));
+        fructose_assert(0 == testee.AddRoute(netId_1, local_name));
         fructose_assert(!!testee.GetConnection(netId_1));
         fructose_assert(ip_local == testee.GetConnection(netId_1)->destIp);
 
         // existent Ams with new Ip -> close old connection manually, now
-        fructose_assert(ROUTERERR_PORTALREADYINUSE == testee.AddRoute(netId_1, ip_remote));
+        fructose_assert(ROUTERERR_PORTALREADYINUSE == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
         fructose_assert(ip_local == testee.GetConnection(netId_1)->destIp);
         testee.DelRoute(netId_1);
-        fructose_assert(0 == testee.AddRoute(netId_1, ip_remote));
+        fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
         fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
 
         // new Ams with existent Ip
-        fructose_assert(0 == testee.AddRoute(netId_2, ip_remote));
+        fructose_assert(0 == testee.AddRoute(netId_2, remote_name));
         fructose_assert(!!testee.GetConnection(netId_2));
         fructose_assert(ip_remote == testee.GetConnection(netId_2)->destIp);
 
         // already exists
-        fructose_assert(0 == testee.AddRoute(netId_1, ip_remote));
+        fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
         fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
     }
@@ -129,21 +130,22 @@ struct TestAmsRouter : test_base<TestAmsRouter> {
     {
         static const AmsNetId netId_1 { 192, 168, 0, 231, 1, 1 };
         static const AmsNetId netId_2 { 127, 0, 0, 1, 2, 1 };
-        static const IpV4 ip_local("127.0.0.1");
+        static const auto local_name = "127.0.0.1";
+        static const IpV4 ip_local(local_name);
         AmsRouter testee;
 
         // add + remove -> null
-        fructose_assert(0 == testee.AddRoute(netId_1, ip_remote));
+        fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
         fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
         testee.DelRoute(netId_1);
         fructose_assert(!testee.GetConnection(netId_1));
 
         // add_1, add_2, remove_1 -> null_1 valid_2
-        fructose_assert(0 == testee.AddRoute(netId_1, ip_remote));
+        fructose_assert(0 == testee.AddRoute(netId_1, remote_name));
         fructose_assert(!!testee.GetConnection(netId_1));
         fructose_assert(ip_remote == testee.GetConnection(netId_1)->destIp);
-        fructose_assert(0 == testee.AddRoute(netId_2, ip_local));
+        fructose_assert(0 == testee.AddRoute(netId_2, local_name));
         fructose_assert(!!testee.GetConnection(netId_2));
         fructose_assert(ip_local == testee.GetConnection(netId_2)->destIp);
         testee.DelRoute(netId_1);
@@ -186,7 +188,7 @@ private:
     {
         for (uint8_t i = 0; i < 255; ++i) {
             AmsNetId netId {192, 168, 0, i, 0, id};
-            fructose_assert_eq(0, testee.AddRoute(netId, ip_remote));
+            fructose_assert_eq(0, testee.AddRoute(netId, remote_name));
             fructose_assert(!!testee.GetConnection(netId));
             fructose_assert(ip_remote == testee.GetConnection(netId)->destIp);
         }

--- a/AdsLibTestRef/main.cpp
+++ b/AdsLibTestRef/main.cpp
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+/**
+   Copyright (c) 2015 - 2022 Beckhoff Automation GmbH & Co. KG
+ */
+
 #ifdef __FreeBSD__
 #define HAS_WINTYPES 1
 using __int64 = unsigned long long;

--- a/AdsTool/ParameterList.cpp
+++ b/AdsTool/ParameterList.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-    Copyright (C) 2021 Beckhoff Automation GmbH & Co. KG
+    Copyright (C) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
     Author: Patrick Bruenn <p.bruenn@beckhoff.com>
  */
 

--- a/AdsTool/ParameterList.cpp
+++ b/AdsTool/ParameterList.cpp
@@ -12,21 +12,21 @@ namespace bhf
 #define ERR_INVALID_PARAMETER (-2)
 
 template<>
-std::string StringTo<std::string>(const std::string& v)
+std::string StringTo<std::string>(const std::string& v, const std::string)
 {
     return v;
 }
 
 template<>
-bool StringTo<bool>(const std::string& v)
+bool StringTo<bool>(const std::string& v, const bool)
 {
     return !v.compare("true");
 }
 
 template<>
-uint8_t StringTo<uint8_t>(const std::string& v)
+uint8_t StringTo<uint8_t>(const std::string& v, uint8_t defaultValue)
 {
-    return static_cast<uint8_t>(StringTo<uint32_t>(v));
+    return static_cast<uint8_t>(StringTo<uint32_t>(v), defaultValue);
 }
 
 int ParameterList::Parse(int argc, const char* argv[])

--- a/AdsTool/ParameterList.cpp
+++ b/AdsTool/ParameterList.cpp
@@ -26,7 +26,7 @@ bool StringTo<bool>(const std::string& v, const bool)
 template<>
 uint8_t StringTo<uint8_t>(const std::string& v, uint8_t defaultValue)
 {
-    return static_cast<uint8_t>(StringTo<uint32_t>(v), defaultValue);
+    return static_cast<uint8_t>(StringTo<uint32_t>(v, defaultValue));
 }
 
 int ParameterList::Parse(int argc, const char* argv[])

--- a/AdsTool/ParameterList.h
+++ b/AdsTool/ParameterList.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-    Copyright (C) 2021 Beckhoff Automation GmbH & Co. KG
+    Copyright (C) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
     Author: Patrick Bruenn <p.bruenn@beckhoff.com>
  */
 

--- a/AdsTool/ParameterList.h
+++ b/AdsTool/ParameterList.h
@@ -27,9 +27,8 @@ struct ParameterOption {
 };
 
 template<typename T>
-T StringTo(const std::string& v)
+T StringTo(const std::string& v, T value = {})
 {
-    T value = 0;
     if (v.size()) {
         const auto asHex = (v.npos != v.rfind("0x", 0));
         std::stringstream converter;
@@ -39,9 +38,9 @@ T StringTo(const std::string& v)
     return value;
 }
 
-template<> std::string StringTo<>(const std::string& v);
-template<> bool StringTo<bool>(const std::string& v);
-template<> uint8_t StringTo<uint8_t>(const std::string& v);
+template<> std::string StringTo<>(const std::string& v, std::string value);
+template<> bool StringTo<bool>(const std::string& v, bool value);
+template<> uint8_t StringTo<uint8_t>(const std::string& v, uint8_t defaultValue);
 
 struct ParameterList {
     using MapType = std::map<std::string, ParameterOption>;
@@ -56,13 +55,13 @@ struct ParameterList {
     int Parse(int argc, const char* argv[]);
 
     template<typename T>
-    T Get(const std::string& key) const
+    T Get(const std::string& key, const T defaultValue = {}) const
     {
         auto it = map.find(key);
         if (it == map.end()) {
             throw std::runtime_error("invalid parameter " + key);
         }
-        return StringTo<T>(it->second.value);
+        return StringTo<T>(it->second.value, defaultValue);
     }
 };
 

--- a/AdsTool/main.cpp
+++ b/AdsTool/main.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 /**
-    Copyright (C) 2021 Beckhoff Automation GmbH & Co. KG
+    Copyright (C) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
     Author: Patrick Bruenn <p.bruenn@beckhoff.com>
  */
 

--- a/AdsTool/main.cpp
+++ b/AdsTool/main.cpp
@@ -20,7 +20,7 @@
 
 static int version()
 {
-    std::cout << "0.0.10-1\n";
+    std::cout << "0.0.11-1\n";
     return 0;
 }
 

--- a/AdsTool/main.cpp
+++ b/AdsTool/main.cpp
@@ -598,11 +598,9 @@ int ParseCommand(int argc, const char* argv[])
         bhf::ads::SetLocalAddress(make_AmsNetId(localNetId));
     }
 
-    const auto logLevel = global.Get<size_t>("--log-level");
-    if (!localNetId.empty()) {
-        // highest loglevel is error==3, we allow 4 to disable all messages
-        Logger::logLevel = std::max(logLevel, (size_t)4);
-    }
+    const auto logLevel = global.Get<size_t>("--log-level", 1);
+    // highest loglevel is error==3, we allow 4 to disable all messages
+    Logger::logLevel = std::min(logLevel, (size_t)4);
 
     const auto cmd = args.Pop<const char*>("Command is missing");
     if (!strcmp("addroute", cmd)) {

--- a/AdsTool/main.cpp
+++ b/AdsTool/main.cpp
@@ -20,7 +20,7 @@
 
 static int version()
 {
-    std::cout << "0.0.11-1\n";
+    std::cout << "0.0.12-1\n";
     return 0;
 }
 

--- a/AdsTool/main.cpp
+++ b/AdsTool/main.cpp
@@ -222,7 +222,7 @@ COMMANDS:
 typedef int (* CommandFunc)(const AmsNetId, const uint16_t, const std::string&, bhf::Commandline&);
 using CommandMap = std::map<const std::string, CommandFunc>;
 
-int RunAddRoute(const IpV4 remote, bhf::Commandline& args)
+int RunAddRoute(const std::string& remote, bhf::Commandline& args)
 {
     bhf::ParameterList params = {
         {"--addr"},
@@ -301,7 +301,7 @@ int RunLicense(const AmsNetId netid, const uint16_t port, const std::string& gw,
     }
 }
 
-int RunNetId(const IpV4 remote)
+int RunNetId(const std::string& remote)
 {
     AmsNetId netId;
     bhf::ads::GetRemoteAddress(remote, netId);

--- a/AdsTool/main.cpp
+++ b/AdsTool/main.cpp
@@ -516,7 +516,7 @@ int RunVar(const AmsNetId netid, const uint16_t port, const std::string& gw, bhf
 
     case sizeof(uint16_t):
         {
-            const auto writeBuffer = bhf::StringTo<uint16_t>(value);
+            const auto writeBuffer = bhf::ads::htole(bhf::StringTo<uint16_t>(value));
             LOG_VERBOSE("name>" << name << "< value>0x" << std::hex << (uint16_t)writeBuffer << "<\n");
             const auto status = device.WriteReqEx(ADSIGRP_SYM_VALBYHND,
                                                   *handle,
@@ -527,7 +527,7 @@ int RunVar(const AmsNetId netid, const uint16_t port, const std::string& gw, bhf
 
     case sizeof(uint32_t):
         {
-            const auto writeBuffer = bhf::StringTo<uint32_t>(value);
+            const auto writeBuffer = bhf::ads::htole(bhf::StringTo<uint32_t>(value));
             LOG_VERBOSE("name>" << name << "< value>0x" << std::hex << (uint32_t)writeBuffer << "<\n");
             const auto status = device.WriteReqEx(ADSIGRP_SYM_VALBYHND,
                                                   *handle,
@@ -538,7 +538,7 @@ int RunVar(const AmsNetId netid, const uint16_t port, const std::string& gw, bhf
 
     case sizeof(uint64_t):
         {
-            const auto writeBuffer = bhf::StringTo<uint32_t>(value);
+            const auto writeBuffer = bhf::ads::htole(bhf::StringTo<uint32_t>(value));
             LOG_VERBOSE("name>" << name << "< value>0x" << std::hex << (uint64_t)writeBuffer << "<\n");
             const auto status = device.WriteReqEx(ADSIGRP_SYM_VALBYHND,
                                                   *handle,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,17 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Compiler flags and definitions for Visual Studio come here
 endif()
 
-option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+if (WIN32)
+  # need __dllexport/_dllimport declarations on classes & free functions Windows, so default to static linking
+  option(BUILD_SHARED_LIBS "Build using shared libraries" OFF)
+else()
+  option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+endif()
+
+option(ADSLIB_ONLY "Build only the ADS library, not examples or tests" OFF)
 
 add_subdirectory(AdsLib)
-add_subdirectory(AdsLibTest)
-add_subdirectory(example)
+if(ADSLIB_ONLY STREQUAL "OFF")
+    add_subdirectory(AdsLibTest)
+    add_subdirectory(example)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   # Compiler flags and definitions for Visual Studio come here
 endif()
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 add_subdirectory(AdsLib)
 add_subdirectory(AdsLibTest)
 add_subdirectory(example)

--- a/README
+++ b/README
@@ -1,16 +1,17 @@
 This library is intended to provide easy use as ADS client applications running on non-windows systems (e.g. FreeBSD, Linux, ...) to communicate with TwinCAT devices via TCP/IP.
 
-To build this library a recent compiler with C++11 support is required. 
+To build this library a recent compiler with C++14 support is required. 
 
-Currently (2021-03-10) tested with:
+Currently (2022-02-21) tested with:
 ===================================
 
 host (amd64)     | target| compiler
 -----------------|-------|-------------
-FreeBSD 13.0     | amd64 | clang 11.0.0
-Ubuntu 18.04 LTS | amd64 | clang 6.0.0
-Ubuntu 18.04 LTS | amd64 | gcc 7.5.0
-Ubuntu 18.04 LTS | i686  | gcc 7.5.0
+TC/BSD 12        | amd64 | clang 10.0.1
+Debian Bullseye  | amd64 | clang 11.0.1
+Debian Bullseye  | amd64 | gcc 10.2.1
+Debian Bullseye  | i686  | gcc 10.2.1
+Debian Bullseye  | mips  | gcc 10.2.1
 Ubuntu 18.04 LTS | win32 | gcc 5.5.0
 Windows 10       | win64 | gcc 8.3.0
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+adstool (0.0.12-1) bullseye; urgency=medium
+
+  * AdsTool: repair var --type=BOOL/BYTE
+    AdsTool: fix endianess for var command
+
+ -- Patrick Bruenn <p.bruenn@beckhoff.com>  Fri, 04 Mar 2022 20:28:39 +0100
+
 adstool (0.0.11-1) bullseye; urgency=medium
 
   * AdsLib: add IPv6 support

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+adstool (0.0.11-1) bullseye; urgency=medium
+
+  * AdsLib: add IPv6 support
+    AdsLib: support variable TCP port for ADS destination
+    AdsTool: fix broken --log-level option
+
+ -- Patrick Bruenn <p.bruenn@beckhoff.com>  Mon, 21 Feb 2022 14:57:24 +0100
+
 adstool (0.0.10-1) bullseye; urgency=medium
 
   * libads-dev: new package to easily install AdsLib as build dependency

--- a/tools/80_ads_route.sh
+++ b/tools/80_ads_route.sh
@@ -1,20 +1,11 @@
 #!/bin/sh
 # SPDX-License-Identifier: MIT
-# Copyright (C) 2021 Beckhoff Automation GmbH & Co. KG
+# Copyright (C) 2021 - 2022 Beckhoff Automation GmbH & Co. KG
 # Author: Patrick Bruenn <p.bruenn@beckhoff.com>
-
-my_ip() {
-	local _dest_ip="${1}"
-	if ! command -v ip_route_src > /dev/null; then
-		ifconfig "$(route get "${_dest_ip}" | grep "interface:" | cut -d' ' -f4)" inet | tr "[:blank:]" "\n" | awk '/inet|src/{getline; print}'
-	else
-		ip_route_src "${_dest_ip}"
-	fi
-}
 
 add_route_ads() {
 	local _container_ip
-	_container_ip="$(my_ip "${1}")"
+	_container_ip="$(ip_route_src "${1}")"
 	echo "CONTAINER_IP: ${_container_ip}"
 
 	while ! ./build/adstool "${test_device}" addroute "--netid=${_container_ip}.1.1" "--addr=${BHF_CI_NAT_IP-${_container_ip}}" --password=1; do
@@ -23,20 +14,10 @@ add_route_ads() {
 	done
 }
 
-host_as_ip() {
-	local _host="${1}"
-	{
-		# getent hosts will fail for ip or bad hostnames. In case _host was already
-		# an ip address we simply print it again. This would pass back a bad
-		# hostname, too, but we can't easily distingish here so let us fail later.
-		getent hosts "${_host}" || printf '%s' "${_host}"
-	} | cut -f1 -d" "
-}
-
 set -e
 set -u
 
 readonly script_path="$(cd "$(dirname "${0}")" && pwd)"
 readonly test_device=ads-server
 
-add_route_ads "$(host_as_ip "${test_device}")"
+add_route_ads "${test_device}"

--- a/tools/90_run_tests.sh
+++ b/tools/90_run_tests.sh
@@ -6,6 +6,7 @@ set -u
 cleanup() {
 	set +e
 	${ncat_pid+kill ${ncat_pid}}
+	${socat_pid+kill ${socat_pid}}
 }
 trap cleanup EXIT INT TERM
 
@@ -13,6 +14,19 @@ readonly script_path="$(cd "$(dirname "$0")" && pwd)"
 
 "${script_path}/80_ads_route.sh"
 "${script_path}/91_test_AdsTool.sh"
+
+# Setup socat port forwarding to test variable ADS ports. We have no socat on
+# Windows and not yet on TC/BSD, but we want to make sure we test on Linux,
+# where socat should be available!
+if test "Linux" = "$(uname)"; then
+	socat TCP-LISTEN:12345,fork TCP:ads-server:48898 &
+	socat_pid=$!
+	while ! nc -z localhost 12345; do
+		sleep 1
+		echo waiting for socat
+	done
+	./build/adstool "$(./build/adstool ads-server netid)" --gw=127.0.0.1:12345 --localams="$(ip_route_src ads-server).1.1" license systemid
+fi
 
 # setup fake ads server and install cleanup trap
 nc -l 48898 -k &

--- a/tools/91_test_AdsTool.sh
+++ b/tools/91_test_AdsTool.sh
@@ -147,23 +147,37 @@ check_state() {
 }
 
 check_var() {
+	local _response
 	check var --type=BOOL 'MAIN.bInitTest' '1'
-	check var --type=BOOL 'MAIN.bInitTest'
+	_response="$(check var --type=BOOL 'MAIN.bInitTest')"
+	if ! test "${_response}" = '1'; then
+		printf 'check_var() BOOL mismatch:\n>%s<\n>%s<\n' "1" "${_response}" >&2
+		return 1
+	fi
+
 	check var --type=BOOL 'MAIN.bInitTest' '0'
+	_response="$(check var --type=BOOL 'MAIN.bInitTest')"
+	if ! test "${_response}" = '0'; then
+		printf 'check_var() BOOL mismatch:\n>%s<\n>%s<\n' "0" "${_response}" >&2
+		return 1
+	fi
+
 	check var --type=DWORD 'MAIN.nTestCasesFailed' '10'
-	check var --type=DWORD 'MAIN.nTestCasesFailed'
+	_response="$( check var --type=DWORD 'MAIN.nTestCasesFailed')"
+	if ! test "${_response}" = '10'; then
+		printf 'check_var() DWORD mismatch:\n>%s<\n>%s<\n' "10" "${_response}" >&2
+		return 1
+	fi
 
 	local _test_string
 	_test_string="$(date +%F%T)"
 	readonly _test_string
 	check var --type=STRING 'MAIN.sLogPath' "${_test_string}"
-	local _response
 	_response="$(check var --type=STRING 'MAIN.sLogPath')"
 	if ! test "${_test_string}" = "${_response}"; then
 		printf 'check_var() string mismatch:\n>%s<\n>%s<\n' "${_test_string}" "${_response}" >&2
 		return 1
 	fi
-
 }
 
 check_version() {

--- a/tools/91_test_AdsTool.sh
+++ b/tools/91_test_AdsTool.sh
@@ -59,6 +59,23 @@ check_license() {
 	fi
 }
 
+check_loglevel() {
+	local _hidden
+	_hidden="$("${ads_tool}" [] --log-level=4 netid 2>&1 | tee "${tmpfile}" | wc -l)"
+	if test "${_hidden}" -gt 0; then
+		printf 'check_loglevel(): failed.\n--log-level=4 should have disable all messages, but we saw:\n' >&2
+		cat "${tmpfile}"
+		return 1
+	fi
+
+	local _default
+	_default="$("${ads_tool}" [] netid 2>&1 | wc -l)"
+	if ! test "${_default}" -gt 0; then
+		printf 'check_loglevel() failed.\nBy default we should see an error message for our broken hostname\n' >&2
+		return 1
+	fi
+}
+
 check_pciscan() {
 	check pciscan 0x15EC5000
 }
@@ -179,6 +196,9 @@ readonly netid
 trap cleanup EXIT INT TERM
 tmpfile="$(mktemp)"
 readonly tmpfile
+
+# --log-level requires no PLC
+check_loglevel
 
 # always check state first to have the PLC in RUN!
 check_state


### PR DESCRIPTION
My commits are mostly CMake fixes to make things build against the TwinCAT/XAE SDK, i.e. for @janaperic 

But overall it's good for the Alexes to see this too as it's ComModule/ADS related.